### PR TITLE
Cap validate_modified_declarations job at 10 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
     # Do not run on the creation of the repository
     if: github.event.created != true
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Without an explicit timeout, the job runs up to GitHub's default of 360 minutes when a fetch hangs, burning Actions minutes. A 10-minute cap is well above the 2-5 min a healthy single-service PR takes.